### PR TITLE
:white_check_mark: Adding unit test for editor form page

### DIFF
--- a/app/editor/components/editorForm.tsx
+++ b/app/editor/components/editorForm.tsx
@@ -2,14 +2,10 @@
 
 import React, { useState } from "react";
 
-import HeaderNode from '@/app/editor/components/headerMenu';
+import HeaderMenu from '@/app/editor/components/headerMenu';
 import CreateArticleForm from "@/app/editor/components/formComponents/createArticles";
 import UpdateArticleForm from '@/app/editor/components/formComponents/updateArticle';
-
 import ManageArticleForm from '@/app/editor/components/formComponents/manageArticle';
-
-// import ValidateArticleForm from '@/app/editor/components/formComponents/validateArticle';
-// import ShipArticle from '@/app/editor/components/formComponents/shipArticle';
 import CreateUserForm from '@/app/editor/components/formComponents/createUser';
 import ManageUserForm from './formComponents/manageUser';
 
@@ -28,7 +24,7 @@ export default function EditorForm({ role, permissions }: {
 
   return (
     <>
-      <HeaderNode
+      <HeaderMenu
         role={role}
         permissions={permissions}
         setSelection={setSelection}

--- a/test-utils/editor/components/editorForm.test.tsx
+++ b/test-utils/editor/components/editorForm.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import EditorForm from '@/app/editor/components/editorForm';
+
+// Mock child components
+vi.mock('@auth0/nextjs-auth0/server');
+vi.mock('@/app/editor/components/headerMenu', () => ({
+  default: ({ role, permissions, setSelection, selection }: any) => (
+    <div data-testid="header-node">
+      HeaderMenu {role} {permissions} {selection}
+      <button onClick={() => setSelection('createarticles')}>
+        Create Articles
+      </button>
+      <button onClick={() => setSelection('updatearticles')}>
+        Update Articles
+      </button>
+      <button onClick={() => setSelection('managearticles')}>
+        Manage Articles
+      </button>
+      <button onClick={() => setSelection('createuser')}>Create User</button>
+      <button onClick={() => setSelection('manageuser')}>Manage User</button>
+    </div>
+  ),
+}));
+vi.mock('@/app/editor/components/formComponents/createArticles', () => ({
+  default: ({ scrolltoTop }: any) => <div data-testid="create-articles">CreateArticleForm</div>,
+}));
+vi.mock('@/app/editor/components/formComponents/updateArticle', () => ({
+  default: ({ scrolltoTop }: any) => <div data-testid="update-articles">UpdateArticleForm</div>,
+}));
+vi.mock('@/app/editor/components/formComponents/manageArticle', () => ({
+  default: ({ scrolltoTop }: any) => <div data-testid="manage-articles">ManageArticleForm</div>,
+}));
+vi.mock('@/app/editor/components/formComponents/createUser', () => ({
+  default: ({ scrolltoTop }: any) => <div data-testid="create-user">CreateUserForm</div>,
+}));
+vi.mock('@/app/editor/components/formComponents/manageUser', () => ({
+  default: ({ scrolltoTop }: any) => (
+    <div data-testid="manage-user">ManageUserForm</div>
+  ),
+}));
+
+describe('EditorForm', () => {
+  it('renders HeaderMenu with correct props', () => {
+    render(<EditorForm role="admin" permissions="all" />);
+    expect(screen.getByTestId('header-node')).toBeInTheDocument();
+    expect(screen.getByText(/HeaderMenu admin all/)).toBeInTheDocument();
+  });
+
+  it('renders nothing except HeaderMenu and topPointRef div by default', () => {
+    render(<EditorForm role="editor" permissions="edit" />);
+    expect(screen.getByTestId('header-node')).toBeInTheDocument();
+    expect(screen.queryByTestId('create-articles')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('update-articles')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('manage-articles')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('create-user')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('manage-user')).not.toBeInTheDocument();
+  });
+
+  it('renders CreateArticleForm when selection is createarticles', async () => {
+    render(<EditorForm role="editor" permissions="edit" />);
+    act(() => screen.getByText('Create Articles').click());
+    await waitFor(() => {
+      expect(screen.getByTestId('create-articles')).toBeInTheDocument();
+    });
+  });
+
+  it('renders UpdateArticleForm when selection is updatearticles', async () => {
+    render(<EditorForm role="editor" permissions="edit" />);
+    act(() => screen.getByText('Update Articles').click());
+    await waitFor(() => {
+      expect(screen.getByTestId('update-articles')).toBeInTheDocument();
+    });
+  });
+
+  it('renders ManageArticleForm when selection is managearticles', async () => {
+    render(<EditorForm role="editor" permissions="edit" />);
+    act(() => screen.getByText('Manage Articles').click());
+    await waitFor(() => {
+      expect(screen.getByTestId('manage-articles')).toBeInTheDocument();
+    });
+  });
+
+  it('renders CreateUserForm when selection is createuser', async () => {
+    render(<EditorForm role="editor" permissions="edit" />);
+    act(() => screen.getByText('Create User').click());
+    await waitFor(() => {
+      expect(screen.getByTestId('create-user')).toBeInTheDocument();
+    });
+  });
+
+  it('renders ManageUserForm when selection is manageuser', async () => {
+    render(<EditorForm role="editor" permissions="edit" />);
+    act(() => screen.getByText('Manage User').click());
+    await waitFor(() => {
+      expect(screen.getByTestId('manage-user')).toBeInTheDocument();
+    });
+  });
+});

--- a/test-utils/headerNode.test.tsx
+++ b/test-utils/headerNode.test.tsx
@@ -1,4 +1,4 @@
-import HeaderNode from '@/app/editor/components/headerMenu';
+import HeaderMenu from '@/app/editor/components/headerMenu';
 import { render } from '@testing-library/react';
 import { expect, it, vi } from 'vitest';
 
@@ -6,6 +6,6 @@ it('Should render correctly', () => {
   const role = 'admin';
   const permissions = JSON.stringify(['read:articles', 'edit:articles']);
   const setSelection = vi.fn();
-  const { asFragment } = render(<HeaderNode role={role} permissions={permissions} setSelection={setSelection} selection='' />);
+  const { asFragment } = render(<HeaderMenu role={role} permissions={permissions} setSelection={setSelection} selection='' />);
   expect(asFragment()).toMatchSnapshot();
 });


### PR DESCRIPTION
- nothing of importance, really
- had to mock @auth0 for server: it checks in the background like a good middleware :>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Swapped the editor’s header to a new menu component for a cleaner UI and removed obsolete references.

- Tests
  - Added comprehensive unit tests for the editor form flow.
  - Verified header renders correctly and only the header appears by default.
  - Confirmed correct forms display when selecting actions (Create/Update/Manage Articles, Create/Manage Users) via simulated interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->